### PR TITLE
게시글 페이지네이션 구현

### DIFF
--- a/src/main/java/com/fastcampaus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampaus/projectboard/controller/ArticleController.java
@@ -47,8 +47,10 @@ public class ArticleController {
     @GetMapping("/{articleId}")
     public String article(@PathVariable Long articleId, ModelMap map) {
         ArticleWithCommentsResponse article = ArticleWithCommentsResponse.from(articleService.getArticle(articleId));
+
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
+        map.addAttribute("totalCount", articleService.getArticleCount());
 
         return "articles/detail";
     }

--- a/src/main/java/com/fastcampaus/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampaus/projectboard/controller/ArticleController.java
@@ -1,10 +1,13 @@
 package com.fastcampaus.projectboard.controller;
 
 import com.fastcampaus.projectboard.domain.type.SearchType;
+import com.fastcampaus.projectboard.dto.ArticleDto;
 import com.fastcampaus.projectboard.dto.response.ArticleResponse;
 import com.fastcampaus.projectboard.dto.response.ArticleWithCommentsResponse;
 import com.fastcampaus.projectboard.service.ArticleService;
+import com.fastcampaus.projectboard.service.PaginationService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -15,12 +18,15 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @RequestMapping("/articles")
 @Controller
 public class ArticleController {
 
     private final ArticleService articleService;
+    private final PaginationService paginationService;
 
     @GetMapping
     public String articles(
@@ -29,7 +35,11 @@ public class ArticleController {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
             ModelMap map
     ) {
-        map.addAttribute("articles", articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from));
+        Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("paginationBarNumbers", barNumbers);
 
         return "articles/index";
     }

--- a/src/main/java/com/fastcampaus/projectboard/service/ArticleService.java
+++ b/src/main/java/com/fastcampaus/projectboard/service/ArticleService.java
@@ -63,4 +63,8 @@ public class ArticleService {
     public void deleteArticle(long articleId) {
         articleRepository.deleteById(articleId);
     }
+
+    public long getArticleCount() {
+        return articleRepository.count();
+    }
 }

--- a/src/main/java/com/fastcampaus/projectboard/service/PaginationService.java
+++ b/src/main/java/com/fastcampaus/projectboard/service/PaginationService.java
@@ -1,0 +1,24 @@
+package com.fastcampaus.projectboard.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int totalPages) {
+        int startNumber = Math.max(currentPageNumber - (BAR_LENGTH / 2), 0);
+        int endNumber = Math.min(startNumber + BAR_LENGTH, totalPages);
+
+        return IntStream.range(startNumber, endNumber).boxed().toList();
+    }
+
+    public int currentBarLength(){
+        return BAR_LENGTH;
+    }
+
+}

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -33,7 +33,7 @@
           </section>
 
           <article id="article-content" class="col-md-7 col-lg-8">
-              <pre style="white-space:normal">본문<br><br></pre>
+              <pre style="white-space:normal">본문</pre>
           </article>
       </div>
 
@@ -76,7 +76,7 @@
       </div>
 
       <div class="row g-5">
-          <nav aria-label="Page navigation example">
+          <nav id="pagination" aria-label="Page navigation">
               <ul class="pagination">
                   <li class="page-item">
                       <a class="page-link" href="#" aria-label="Previous">

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -10,13 +10,28 @@
         <attr sel="#created-at" th:datetime="*{createdAt}" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
         <attr sel="#hashtag" th:text="*{hashtag}" />
         <attr sel="#article-content/pre" th:text="*{content}" />
-    </attr>
 
-    <attr sel="#article-comments" th:remove="all-but-first">
-        <attr sel="li[0]" th:each="articleComment : ${articleComments}">
-            <attr sel="div/strong" th:text="${articleComment.nickname}" th:href="@{'/articles/' + ${article.id}}"/>
-            <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
-            <attr sel="div/p" th:text="${articleComment.content}"/>
+        <attr sel="#article-comments" th:remove="all-but-first">
+            <attr sel="li[0]" th:each="articleComment : ${articleComments}">
+                <attr sel="div/strong" th:text="${articleComment.nickname}" />
+                <attr sel="div/small/time"
+                      th:datetime="${articleComment.createdAt}"
+                      th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
+                <attr sel="div/p" th:text="${articleComment.content}"/>
+            </attr>
+        </attr>
+
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
+                      th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]/a"
+                      th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
+                      th:class="'page-link' + (*{id} + 1 > ${totalCount} ? ' disabled' : '')"
+                />
+            </attr>
         </attr>
     </attr>
 </thlogic>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -88,12 +88,10 @@
           </tbody>
       </table>
 
-      <nav aria-label="Page navigation example">
+      <nav id="pagination" aria-label="Page navigation example">
           <ul class="pagination justify-content-center">
               <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-              <li class="page-item"><a class="page-link" href="#">1</a></li>
               <li class="page-item"><a class="page-link" href="#">2</a></li>
-              <li class="page-item"><a class="page-link" href="#">3</a></li>
               <li class="page-item"><a class="page-link" href="#">Next</a></li>
           </ul>
       </nav>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -14,4 +14,23 @@
         </attr>
     </attr>
 
+    <attr sel="#pagination">
+        <attr sel="li[0]/a"
+              th:text="'previous'"
+              th:href="@{/articles(page=${articles.number - 1})}"
+              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+        />
+        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+            <attr sel="a"
+                  th:text="${pageNumber + 1}"
+                  th:href="@{/articles(page=${pageNumber})}"
+                  th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+            />
+        </attr>
+        <attr sel="li[2]/a"
+              th:text="'next'"
+              th:href="@{/articles(page=${articles.number + 1})}"
+              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+        />
+    </attr>
 </thlogic>

--- a/src/test/java/com/fastcampaus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampaus/projectboard/controller/ArticleControllerTest.java
@@ -91,12 +91,15 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @DisplayName("[view][GET] 게시글 상세 페이지 - 정상 호출")
+    @DisplayName("[view][GET] 게시글 페이지 - 정상 호출")
     @Test
     public void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {
         // Given
         Long articleId = 1L;
+        long totalCount = 1L;
+
         given(articleService.getArticle(articleId)).willReturn(createArticleWithCommentsDto());
+        given(articleService.getArticleCount()).willReturn(totalCount);
 
         // When & Then
         mvc.perform(get("/articles/" + articleId))
@@ -104,8 +107,10 @@ class ArticleControllerTest {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/detail"))
                 .andExpect(model().attributeExists("article"))
-                .andExpect(model().attributeExists("articleComments"));
+                .andExpect(model().attributeExists("articleComments"))
+                .andExpect(model().attribute("totalCount", totalCount));
         then(articleService).should().getArticle(articleId);
+        then(articleService).should().getArticleCount();
     }
 
     @Disabled("구현 중")

--- a/src/test/java/com/fastcampaus/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/fastcampaus/projectboard/controller/ArticleControllerTest.java
@@ -5,6 +5,7 @@ import com.fastcampaus.projectboard.domain.Article;
 import com.fastcampaus.projectboard.dto.ArticleWithCommentsDto;
 import com.fastcampaus.projectboard.dto.UserAccountDto;
 import com.fastcampaus.projectboard.service.ArticleService;
+import com.fastcampaus.projectboard.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,16 +14,18 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -35,6 +38,7 @@ class ArticleControllerTest {
     private final MockMvc mvc;
 
     @MockBean private ArticleService articleService;
+    @MockBean private PaginationService paginationService;
 
     public ArticleControllerTest(@Autowired MockMvc mvc) {
         this.mvc = mvc;
@@ -45,14 +49,46 @@ class ArticleControllerTest {
     public void givenNothing_whenRequestingArticlesView_thenReturnsArticlesView() throws Exception {
         // Given
         given(articleService.searchArticles(eq(null), eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(), anyInt())).willReturn(List.of(0, 1, 2, 3, 4));
 
         // When & Then
         mvc.perform(get("/articles"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("articles/index"))
-                .andExpect(model().attributeExists("articles"));
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
+
+    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 페이징, 정렬 기능")
+    @Test
+    public void givenPagingAndSortingParams_whenSearchingArticlePages_thenReturnsArticlesView() throws Exception {
+        // Given
+        String sortName = "title";
+        String direction = "desc";
+        int pageNumber = 0;
+        int pageSize = 5;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Order.desc(sortName)));
+        List<Integer> barNumbers = List.of(1, 2, 3, 4, 5);
+        given(articleService.searchArticles(null, null, pageable)).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages())).willReturn(barNumbers);
+
+        // When & Then
+        mvc.perform(
+                    get("/articles")
+                            .queryParam("page", String.valueOf(pageNumber))
+                            .queryParam("size", String.valueOf(pageSize))
+                            .queryParam("sort", sortName + "," + direction)
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attribute("paginationBarNumbers", barNumbers));
+        then(articleService).should().searchArticles(null, null, pageable);
+        then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
     @DisplayName("[view][GET] 게시글 상세 페이지 - 정상 호출")

--- a/src/test/java/com/fastcampaus/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampaus/projectboard/service/ArticleServiceTest.java
@@ -163,6 +163,21 @@ class ArticleServiceTest {
         then(articleRepository).should().deleteById(articleId);
     }
 
+    @DisplayName("게시글의 수를 조회하면, 게시글 수를 반환한다.")
+    @Test
+    void givenNothing_whenCountingArticles_thenReturnsArticleCount() {
+        // Given
+        long expected = 0L;
+        given(articleRepository.count()).willReturn(expected);
+
+        // When
+        long actual = sut.getArticleCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(articleRepository).should().count();
+    }
+
     private ArticleDto createArticleDto() {
         return createArticleDto("title", "content", "#java");
     }

--- a/src/test/java/com/fastcampaus/projectboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/fastcampaus/projectboard/service/PaginationServiceTest.java
@@ -1,0 +1,66 @@
+package com.fastcampaus.projectboard.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("비지니스 로직 - 페이지네이션")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE, classes = PaginationService.class)
+class PaginationServiceTest {
+
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService paginationService) {
+        this.sut = paginationService;
+    }
+
+    @DisplayName("현재 페이지 번호와 총 페이지 수를 주면, 페이징 바 리스트를 만들어 준다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] 현재 페이지: {0}, 총 페이지: {1} => {2}")
+    void givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expected) {
+        // Given
+
+        // When
+        List<Integer> actual = sut.getPaginationBarNumbers(currentPageNumber, totalPages);
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers() {
+        return Stream.of(
+                arguments(0, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(1, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(2, 13, List.of(0, 1, 2, 3, 4)),
+                arguments(3, 13, List.of(1, 2, 3, 4, 5)),
+                arguments(4, 13, List.of(2, 3, 4, 5, 6)),
+                arguments(5, 13, List.of(3, 4, 5, 6, 7)),
+                arguments(6, 13, List.of(4, 5, 6, 7, 8)),
+                arguments(10, 13, List.of(8, 9, 10, 11, 12)),
+                arguments(11, 13, List.of(9, 10, 11, 12)),
+                arguments(12, 13, List.of(10, 11, 12))
+        );
+    }
+
+    @DisplayName("현재 설정되어 있는 페이지네이션 바의 길이를 알려준다.")
+    @Test
+    void given_when_then() {
+        // Given
+
+        // When
+        int barLength = sut.currentBarLength();
+
+        // Then
+        assertThat(barLength).isEqualTo(5);
+    }
+}


### PR DESCRIPTION
`이전 글`, `다음 글`만 구현하므로 게시판에 비해 단순하지만 첫 글, 마지막 글은 버튼 비활성화 및 가짜 링크 처리해야해서 타임리프 문법이 복잡해짐

마지막 글을 판단하기 위해 총 글 갯수가 필요해졌고
이를 위해 count 쿼리 사용, 서비스 로직 추가

This closes #33